### PR TITLE
Be/fix/video upload

### DIFF
--- a/Backend/ifIDieTomorrow/src/main/java/com/a307/ifIDieTomorrow/domain/controller/BucketController.java
+++ b/Backend/ifIDieTomorrow/src/main/java/com/a307/ifIDieTomorrow/domain/controller/BucketController.java
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.HashMap;
 import java.util.List;
 
@@ -43,7 +44,9 @@ public class BucketController {
 	public ResponseEntity<CreateBucketResDto> createBucket(
 			@RequestPart CreateBucketDto data,
 			@RequestPart(required = false) MultipartFile photo) throws IOException, NoPhotoException, ImageProcessingException, MetadataException, IllegalArgumentException {
-		if (photo != null && !FileChecker.imageCheck(photo.getInputStream())) throw new IllegalArgumentException("허용되지 않은 확장자입니다.");
+		// photo가 null이 아니면서 이미지도 영상도 아니라면 예외 던짐
+		InputStream is = photo.getInputStream();
+		if (photo != null && !FileChecker.imageCheck(is) && !FileChecker.videoCheck(is)) throw new IllegalArgumentException("허용되지 않은 확장자입니다.");
 		return ResponseEntity.status(HttpStatus.CREATED).body(bucketService.createBucket(data, photo));
 	}
 
@@ -67,7 +70,9 @@ public class BucketController {
 	public ResponseEntity<CreateBucketResDto> updateBucket(
 			@RequestPart UpdateBucketDto data,
 			@RequestPart(required = false) MultipartFile photo) throws IOException, NotFoundException, ImageProcessingException, UnAuthorizedException, MetadataException, IllegalArgumentException {
-		if (photo != null && !FileChecker.imageCheck(photo.getInputStream())) throw new IllegalArgumentException("허용되지 않은 확장자입니다.");
+		// photo가 null이 아니면서 이미지도 영상도 아니라면 예외 던짐
+		InputStream is = photo.getInputStream();
+		if (photo != null && !FileChecker.imageCheck(is) && !FileChecker.videoCheck(is)) throw new IllegalArgumentException("허용되지 않은 확장자입니다.");
 		return ResponseEntity.status(HttpStatus.OK).body(bucketService.updateBucket(data, photo));
 	}
 	

--- a/Backend/ifIDieTomorrow/src/main/java/com/a307/ifIDieTomorrow/domain/controller/DiaryController.java
+++ b/Backend/ifIDieTomorrow/src/main/java/com/a307/ifIDieTomorrow/domain/controller/DiaryController.java
@@ -20,6 +20,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.HashMap;
 import java.util.List;
 
@@ -37,7 +38,7 @@ public class DiaryController {
 			@RequestPart(value = "data") CreateDiaryReqDto data,
 			@RequestPart(required = false, value = "photo") MultipartFile photo
 			) throws IOException, NotFoundException, NoPhotoException, IllegalArgumentException, ImageProcessingException, MetadataException {
-		if (photo != null && !FileChecker.imageCheck(photo.getInputStream())) throw new IllegalArgumentException("허용되지 않은 확장자입니다.");
+		if (photo != null && !FileChecker.imageCheck(photo.getInputStream()) && !FileChecker.videoCheck(photo.getInputStream())) throw new IllegalArgumentException("허용되지 않은 확장자입니다.");
 		return ResponseEntity.status(HttpStatus.CREATED).body(diaryService.createDiary(data, photo));
 	}
 
@@ -66,7 +67,7 @@ public class DiaryController {
 			@RequestPart(value = "data") UpdateDiaryReqDto data,
 			@RequestPart(value = "photo", required = false) MultipartFile photo
 			) throws NotFoundException, IOException, IllegalArgumentException, UnAuthorizedException, ImageProcessingException, MetadataException {
-		if (photo != null && !FileChecker.imageCheck(photo.getInputStream())) throw new IllegalArgumentException("허용되지 않은 확장자입니다.");
+		if (photo != null && !FileChecker.imageCheck(photo.getInputStream()) && !FileChecker.videoCheck(photo.getInputStream())) throw new IllegalArgumentException("허용되지 않은 확장자입니다.");
 		return ResponseEntity.status(HttpStatus.OK).body(diaryService.updateDiary(data, photo));
 	}
 	

--- a/Backend/ifIDieTomorrow/src/main/java/com/a307/ifIDieTomorrow/domain/controller/PhotoController.java
+++ b/Backend/ifIDieTomorrow/src/main/java/com/a307/ifIDieTomorrow/domain/controller/PhotoController.java
@@ -86,7 +86,7 @@ public class PhotoController {
 	public ResponseEntity<CreatePhotoResDto> createPhoto(
 			@RequestPart CreatePhotoDto data,
 			@RequestPart MultipartFile photo) throws IOException, NoPhotoException, IllegalArgumentException, NotFoundException, UnAuthorizedException, ImageProcessingException, MetadataException {
-		if (!FileChecker.imageCheck(photo.getInputStream())) throw new IllegalArgumentException("허용되지 않은 확장자입니다.");
+		if (!FileChecker.imageCheck(photo.getInputStream()) && !FileChecker.videoCheck(photo.getInputStream())) throw new IllegalArgumentException("허용되지 않은 확장자입니다.");
 		return ResponseEntity.status(HttpStatus.CREATED).body(photoService.createPhoto(data, photo));
 	}
 	

--- a/Backend/ifIDieTomorrow/src/main/java/com/a307/ifIDieTomorrow/domain/dto/bucket/CreateBucketResDto.java
+++ b/Backend/ifIDieTomorrow/src/main/java/com/a307/ifIDieTomorrow/domain/dto/bucket/CreateBucketResDto.java
@@ -17,6 +17,7 @@ public class CreateBucketResDto {
 	private String imageUrl;
 	private Boolean secret;
 	private Integer report;
+	private String imageType;
 	private LocalDateTime createdAt;
 	private LocalDateTime updatedAt;
 	
@@ -30,6 +31,7 @@ public class CreateBucketResDto {
 				bucket.getImageUrl(),
 				bucket.getSecret(),
 				bucket.getReport(),
+				bucket.getImageType(),
 				bucket.getCreatedAt(),
 				bucket.getUpdatedAt()
 		);

--- a/Backend/ifIDieTomorrow/src/main/java/com/a307/ifIDieTomorrow/domain/dto/bucket/GetBucketResDto.java
+++ b/Backend/ifIDieTomorrow/src/main/java/com/a307/ifIDieTomorrow/domain/dto/bucket/GetBucketResDto.java
@@ -21,6 +21,7 @@ public class GetBucketResDto {
 	private String complete;
 	private String imageUrl;
 	private Boolean secret;
+	private String imageType;
 	private LocalDateTime createdAt;
 	private LocalDateTime updatedAt;
 

--- a/Backend/ifIDieTomorrow/src/main/java/com/a307/ifIDieTomorrow/domain/dto/diary/CreateDiaryResDto.java
+++ b/Backend/ifIDieTomorrow/src/main/java/com/a307/ifIDieTomorrow/domain/dto/diary/CreateDiaryResDto.java
@@ -26,6 +26,8 @@ public class CreateDiaryResDto {
 	private Boolean secret;
 
 	private Integer report;
+	
+	private String imageType;
 
 	private LocalDateTime createdAt;
 
@@ -40,6 +42,7 @@ public class CreateDiaryResDto {
 				.imageUrl(diary.getImageUrl())
 				.secret(diary.getSecret())
 				.report(diary.getReport())
+				.imageType(diary.getImageType())
 				.createdAt(diary.getCreatedAt())
 				.updatedAt(diary.getUpdatedAt())
 				.build();

--- a/Backend/ifIDieTomorrow/src/main/java/com/a307/ifIDieTomorrow/domain/dto/diary/GetDiaryByUserResDto.java
+++ b/Backend/ifIDieTomorrow/src/main/java/com/a307/ifIDieTomorrow/domain/dto/diary/GetDiaryByUserResDto.java
@@ -23,6 +23,8 @@ public class GetDiaryByUserResDto {
 	private String imageUrl;
 
 	private Boolean secret;
+	
+	private String imageType;
 
 	private LocalDateTime createdAt;
 

--- a/Backend/ifIDieTomorrow/src/main/java/com/a307/ifIDieTomorrow/domain/dto/diary/GetDiaryResDto.java
+++ b/Backend/ifIDieTomorrow/src/main/java/com/a307/ifIDieTomorrow/domain/dto/diary/GetDiaryResDto.java
@@ -26,6 +26,8 @@ public class GetDiaryResDto {
 	private String imageUrl;
 
 	private Boolean secret;
+	
+	private String imageType;
 
 	private LocalDateTime createdAt;
 

--- a/Backend/ifIDieTomorrow/src/main/java/com/a307/ifIDieTomorrow/domain/dto/photo/CreatePhotoResDto.java
+++ b/Backend/ifIDieTomorrow/src/main/java/com/a307/ifIDieTomorrow/domain/dto/photo/CreatePhotoResDto.java
@@ -14,6 +14,7 @@ public class CreatePhotoResDto {
 	private Long categoryId;
 	private String imageUrl;
 	private String caption;
+	private String imageType;
 	private LocalDateTime createdAt;
 	private LocalDateTime updatedAt;
 	
@@ -23,6 +24,7 @@ public class CreatePhotoResDto {
 				photo.getCategory().getCategoryId(),
 				photo.getImageUrl(),
 				photo.getCaption(),
+				photo.getImageType(),
 				photo.getCreatedAt(),
 				photo.getUpdatedAt()
 		);

--- a/Backend/ifIDieTomorrow/src/main/java/com/a307/ifIDieTomorrow/domain/dto/photo/GetPhotoResDto.java
+++ b/Backend/ifIDieTomorrow/src/main/java/com/a307/ifIDieTomorrow/domain/dto/photo/GetPhotoResDto.java
@@ -12,6 +12,7 @@ public class GetPhotoResDto {
 	private Long photoId;
 	private String imageUrl;
 	private String caption;
+	private String imageType;
 	private LocalDateTime createdAt;
 	private LocalDateTime updatedAt;
 	

--- a/Backend/ifIDieTomorrow/src/main/java/com/a307/ifIDieTomorrow/domain/entity/Bucket.java
+++ b/Backend/ifIDieTomorrow/src/main/java/com/a307/ifIDieTomorrow/domain/entity/Bucket.java
@@ -34,22 +34,23 @@ public class Bucket extends BaseEntity {
 	
 	private String complete;
 	
-	@Column
 	private String imageUrl;
 	
-	@Column
 	private Boolean secret;
 	
 	@Column(nullable = false)
 	@ColumnDefault("0")
 	private Integer report;
 	
-	public void updateBucket (String title, String content, String complete, String imageUrl, Boolean secret) {
+	private String imageType;
+	
+	public void updateBucket (String title, String content, String complete, String imageUrl, Boolean secret, String imageType) {
 		this.title = title;
 		this.content = content;
 		this.complete = complete;
 		this.imageUrl = imageUrl;
 		this.secret = secret;
+		this.imageType = imageType;
 	}
 	
 	public void updateTitle(String title) {

--- a/Backend/ifIDieTomorrow/src/main/java/com/a307/ifIDieTomorrow/domain/entity/Diary.java
+++ b/Backend/ifIDieTomorrow/src/main/java/com/a307/ifIDieTomorrow/domain/entity/Diary.java
@@ -42,12 +42,14 @@ public class Diary extends BaseEntity{
 	@ColumnDefault("0")
 	private Integer report;
 
+	private String imageType;
 
-	public void updateDiary(String title, String content, String imageUrl, Boolean secret) {
+	public void updateDiary(String title, String content, String imageUrl, Boolean secret, String imageType) {
 		this.title = title;
 		this.content = content;
 		this.imageUrl = imageUrl;
 		this.secret = secret;
+		this.imageType = imageType;
 	}
 
 	public void reportDiary(){

--- a/Backend/ifIDieTomorrow/src/main/java/com/a307/ifIDieTomorrow/domain/entity/Photo.java
+++ b/Backend/ifIDieTomorrow/src/main/java/com/a307/ifIDieTomorrow/domain/entity/Photo.java
@@ -33,6 +33,8 @@ public class Photo extends BaseEntity {
 	@Column(columnDefinition = "TEXT")
 	private String caption;
 	
+	private String imageType;
+	
 	public void updateCategory (String caption) {
 		this.caption = caption;
 	}

--- a/Backend/ifIDieTomorrow/src/main/java/com/a307/ifIDieTomorrow/domain/repository/BucketRepository.java
+++ b/Backend/ifIDieTomorrow/src/main/java/com/a307/ifIDieTomorrow/domain/repository/BucketRepository.java
@@ -26,7 +26,7 @@ public interface BucketRepository extends JpaRepository<Bucket, Long> {
 	List<Bucket> findAllByUserId (Long userId);
 	
 	@Query("SELECT NEW com.a307.ifIDieTomorrow.domain.dto.bucket.GetBucketResDto" +
-			"(b.bucketId, b.userId, u.nickname, b.title, b.content, b.complete, b.imageUrl, b.secret, b.createdAt, b.updatedAt) " +
+			"(b.bucketId, b.userId, u.nickname, b.title, b.content, b.complete, b.imageUrl, b.secret, b.imageType, b.createdAt, b.updatedAt) " +
 			"FROM Bucket b " +
 			"JOIN User u " +
 			"ON b.userId = u.userId " +
@@ -34,7 +34,7 @@ public interface BucketRepository extends JpaRepository<Bucket, Long> {
 	Optional<GetBucketResDto> findByBucketIdWithUserNickName (@Param("bucketId") Long bucketId);
 
 	@Query("SELECT NEW com.a307.ifIDieTomorrow.domain.dto.bucket.GetBucketResDto" +
-			"(b.bucketId, b.userId, u.nickname, b.title, b.content, b.complete, b.imageUrl, b.secret, b.createdAt, b.updatedAt) " +
+			"(b.bucketId, b.userId, u.nickname, b.title, b.content, b.complete, b.imageUrl, b.secret, b.imageType, b.createdAt, b.updatedAt) " +
 			"FROM Bucket b " +
 			"JOIN User u " +
 			"ON b.userId = u.userId " +
@@ -44,7 +44,7 @@ public interface BucketRepository extends JpaRepository<Bucket, Long> {
 	Page<GetBucketResDto> findAllBySecretIsFalseAndReportUnderLimit(Pageable pageable, @Param("reportLimit") Integer reportLimit);
 
 	@Query("SELECT NEW com.a307.ifIDieTomorrow.domain.dto.bucket.GetBucketResDto" +
-			"(b.bucketId, b.userId, u.nickname, b.title, b.content, b.complete, b.imageUrl, b.secret, b.createdAt, b.updatedAt) " +
+			"(b.bucketId, b.userId, u.nickname, b.title, b.content, b.complete, b.imageUrl, b.secret, b.imageType, b.createdAt, b.updatedAt) " +
 			"FROM Bucket b " +
 			"JOIN User u " +
 			"ON b.userId = u.userId " +

--- a/Backend/ifIDieTomorrow/src/main/java/com/a307/ifIDieTomorrow/domain/repository/DiaryRepository.java
+++ b/Backend/ifIDieTomorrow/src/main/java/com/a307/ifIDieTomorrow/domain/repository/DiaryRepository.java
@@ -15,7 +15,7 @@ import java.util.Optional;
 public interface DiaryRepository extends JpaRepository<Diary, Long> {
 
 	@Query("SELECT new com.a307.ifIDieTomorrow.domain.dto.diary.GetDiaryByUserResDto" +
-			"(d.diaryId, d.title, d.content, d.imageUrl, d.secret, d.createdAt, d.updatedAt, COUNT(c.commentId)) " +
+			"(d.diaryId, d.title, d.content, d.imageUrl, d.secret, d.imageType, d.createdAt, d.updatedAt, COUNT(c.commentId)) " +
 			"FROM Diary d " +
 			"LEFT JOIN Comment c " +
 			"ON d.diaryId = c.typeId " +
@@ -25,7 +25,7 @@ public interface DiaryRepository extends JpaRepository<Diary, Long> {
 	List<GetDiaryByUserResDto> findAllByUserIdWithCommentCount (@Param("userId") Long userId);
 
 	@Query("SELECT NEW com.a307.ifIDieTomorrow.domain.dto.diary.GetDiaryResDto" +
-			"(d.diaryId, d.userId, u.nickname, d.title, d.content, d.imageUrl, d.secret, d.createdAt, d.updatedAt) " +
+			"(d.diaryId, d.userId, u.nickname, d.title, d.content, d.imageUrl, d.secret, d.imageType, d.createdAt, d.updatedAt) " +
 			"FROM Diary d " +
 			"JOIN User u " +
 			"ON d.userId = u.userId " +
@@ -35,14 +35,14 @@ public interface DiaryRepository extends JpaRepository<Diary, Long> {
 	Page<GetDiaryResDto> findAllBySecretIsFalseAndReportUnderLimit(Pageable pageable, @Param("reportLimit") Integer reportLimit);
 
 	@Query("SELECT NEW com.a307.ifIDieTomorrow.domain.dto.diary.GetDiaryResDto" +
-			"(d.diaryId, d.userId, u.nickname, d.title, d.content, d.imageUrl, d.secret, d.createdAt, d.updatedAt) " +
+			"(d.diaryId, d.userId, u.nickname, d.title, d.content, d.imageUrl, d.secret, d.imageType, d.createdAt, d.updatedAt) " +
 			"FROM Diary d " +
 			"JOIN User u " +
 			"ON d.userId = u.userId " +
 			"WHERE d.diaryId = :diaryId AND u.deleted = false")
 	Optional<GetDiaryResDto> findByIdWithUserNickName(@Param("diaryId") Long diaryId);
 	@Query("SELECT NEW com.a307.ifIDieTomorrow.domain.dto.diary.GetDiaryResDto" +
-			"(d.diaryId, d.userId, u.nickname, d.title, d.content, d.imageUrl, d.secret, d.createdAt, d.updatedAt) " +
+			"(d.diaryId, d.userId, u.nickname, d.title, d.content, d.imageUrl, d.secret, d.imageType, d.createdAt, d.updatedAt) " +
 			"FROM Diary d " +
 			"JOIN User u " +
 			"ON d.userId = u.userId " +

--- a/Backend/ifIDieTomorrow/src/main/java/com/a307/ifIDieTomorrow/domain/repository/PhotoRepository.java
+++ b/Backend/ifIDieTomorrow/src/main/java/com/a307/ifIDieTomorrow/domain/repository/PhotoRepository.java
@@ -15,7 +15,7 @@ import java.util.Optional;
 @Repository
 public interface PhotoRepository extends JpaRepository<Photo, Long> {
 	@Query("SELECT new com.a307.ifIDieTomorrow.domain.dto.photo.GetPhotoResDto" +
-			"(photoId, imageUrl, caption, createdAt, updatedAt) " +
+			"(photoId, imageUrl, caption, imageType, createdAt, updatedAt) " +
 			"FROM Photo " +
 			"WHERE category.categoryId = :categoryId AND userId = :userId " +
 			"ORDER BY createdAt DESC")

--- a/Backend/ifIDieTomorrow/src/main/java/com/a307/ifIDieTomorrow/domain/service/BucketServiceImpl.java
+++ b/Backend/ifIDieTomorrow/src/main/java/com/a307/ifIDieTomorrow/domain/service/BucketServiceImpl.java
@@ -60,9 +60,8 @@ public class BucketServiceImpl implements BucketService {
 		
 		String type = null;
 		if (photo != null) {
-			InputStream is = photo.getInputStream();
-			if (FileChecker.videoCheck(is)) type = "video";
-			else if (FileChecker.imageCheck(is)) type = "image";
+			if (FileChecker.videoCheck(photo.getInputStream())) type = "video";
+			else type = "image";
 		}
 		
 		Bucket bucket = Bucket.builder().
@@ -120,9 +119,8 @@ public class BucketServiceImpl implements BucketService {
 		
 		String type = null;
 		if (photo != null) {
-			InputStream is = photo.getInputStream();
-			if (FileChecker.videoCheck(is)) type = "video";
-			else if (FileChecker.imageCheck(is)) type = "image";
+			if (FileChecker.videoCheck(photo.getInputStream())) type = "video";
+			else type = "image";
 		}
 		
 		bucket.updateBucket(
@@ -131,7 +129,7 @@ public class BucketServiceImpl implements BucketService {
 				data.getComplete(),
 				data.getUpdatePhoto() ? (photo == null ? "" : s3Upload.upload(photo, BUCKET)) : bucket.getImageUrl(),
 				data.getSecret(),
-				data.getUpdatePhoto() ? (photo == null ? null : type) : bucket.getImageType()
+				data.getUpdatePhoto() ? type : bucket.getImageType()
 		);
 		
 		return CreateBucketResDto.toDto(bucketRepository.save(bucket));

--- a/Backend/ifIDieTomorrow/src/main/java/com/a307/ifIDieTomorrow/domain/service/DiaryServiceImpl.java
+++ b/Backend/ifIDieTomorrow/src/main/java/com/a307/ifIDieTomorrow/domain/service/DiaryServiceImpl.java
@@ -10,6 +10,7 @@ import com.a307.ifIDieTomorrow.global.exception.NoPhotoException;
 import com.a307.ifIDieTomorrow.global.exception.NotFoundException;
 import com.a307.ifIDieTomorrow.global.exception.UnAuthorizedException;
 import com.a307.ifIDieTomorrow.global.util.FamousSayingGenerator;
+import com.a307.ifIDieTomorrow.global.util.FileChecker;
 import com.a307.ifIDieTomorrow.global.util.S3Upload;
 import com.drew.imaging.ImageProcessingException;
 import com.drew.metadata.MetadataException;
@@ -21,6 +22,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.HashMap;
 import java.util.List;
 
@@ -42,7 +44,12 @@ public class DiaryServiceImpl implements DiaryService{
 //
 //		사진 검증
 		if (req.getHasPhoto() && (photo == null || photo.isEmpty())) throw new NoPhotoException("올리고자 하는 사진이 없습니다");
-
+		
+		String type = null;
+		if (photo != null) {
+			if (FileChecker.videoCheck(photo.getInputStream())) type = "video";
+			else type = "image";
+		}
 
 		return CreateDiaryResDto.toDto(
 				diaryRepository.save(Diary.builder()
@@ -52,6 +59,7 @@ public class DiaryServiceImpl implements DiaryService{
 								.secret(req.getSecret())
 								.report(0)
 								.imageUrl(req.getHasPhoto() ? s3Upload.upload(photo, "diary") : "")
+								.imageType(type)
 								.build()
 				)
 		);
@@ -115,12 +123,19 @@ public class DiaryServiceImpl implements DiaryService{
 
 //		기존 사진 삭제
 		if (req.getUpdatePhoto() && diary.getImageUrl() != null && !"".equals(diary.getImageUrl())) s3Upload.delete(diary.getImageUrl());
+		
+		String type = null;
+		if (photo != null) {
+			if (FileChecker.videoCheck(photo.getInputStream())) type = "video";
+			else type = "image";
+		}
 
 		diary.updateDiary(
 				req.getTitle(),
 				req.getContent(),
 				req.getUpdatePhoto() ? (photo == null ? "" : s3Upload.upload(photo, "diary")) : diary.getImageUrl(),
-				req.getSecret()
+				req.getSecret(),
+				req.getUpdatePhoto() ? type : diary.getImageType()
 		);
 
 		return CreateDiaryResDto.toDto(diaryRepository.save(diary));

--- a/Backend/ifIDieTomorrow/src/main/java/com/a307/ifIDieTomorrow/domain/service/PhotoServiceImpl.java
+++ b/Backend/ifIDieTomorrow/src/main/java/com/a307/ifIDieTomorrow/domain/service/PhotoServiceImpl.java
@@ -17,6 +17,7 @@ import com.a307.ifIDieTomorrow.global.exception.IllegalArgumentException;
 import com.a307.ifIDieTomorrow.global.exception.NoPhotoException;
 import com.a307.ifIDieTomorrow.global.exception.NotFoundException;
 import com.a307.ifIDieTomorrow.global.exception.UnAuthorizedException;
+import com.a307.ifIDieTomorrow.global.util.FileChecker;
 import com.a307.ifIDieTomorrow.global.util.ImageProcess;
 import com.a307.ifIDieTomorrow.global.util.S3Upload;
 import com.drew.imaging.ImageProcessingException;
@@ -137,11 +138,18 @@ public class PhotoServiceImpl implements PhotoService {
 		// 공용 카테고리가 아니면서 다른 유저가 만든 카테고리에 업로드하려 할 때
 		if (category.getUserId() != 0 && !category.getUserId().equals(userId)) throw new UnAuthorizedException("접근할 수 없는 카테고리 ID 입니다.");
 		
+		String type = null;
+		if (photo != null) {
+			if (FileChecker.videoCheck(photo.getInputStream())) type = "video";
+			else type = "image";
+		}
+		
 		Photo photoEntity = Photo.builder().
 				category(category).
 				userId(userId).
 				imageUrl(s3Upload.upload(photo, PHOTO)).
 				caption(data.getCaption()).
+				imageType(type).
 				build();
 		
 		return CreatePhotoResDto.toDto(photoRepository.save(photoEntity));

--- a/Backend/ifIDieTomorrow/src/main/java/com/a307/ifIDieTomorrow/global/util/FileChecker.java
+++ b/Backend/ifIDieTomorrow/src/main/java/com/a307/ifIDieTomorrow/global/util/FileChecker.java
@@ -23,7 +23,7 @@ public class FileChecker {
 	}
 	
 	public static boolean videoCheck (InputStream inputStream) throws IOException {
-		List<String> validTypeList = Arrays.asList("video/mp4", "video/avi", "video/webm", "application/x-matroska", "video/quicktime", "application/octet-stream");
+		List<String> validTypeList = Arrays.asList("video/mp4", "video/avi", "video/webm", "application/x-matroska", "video/quicktime");
 		
 		String mimeType = tika.detect(inputStream);
 		log.info("MimeType : " + mimeType);

--- a/Backend/ifIDieTomorrow/src/main/java/com/a307/ifIDieTomorrow/global/util/FileChecker.java
+++ b/Backend/ifIDieTomorrow/src/main/java/com/a307/ifIDieTomorrow/global/util/FileChecker.java
@@ -23,7 +23,7 @@ public class FileChecker {
 	}
 	
 	public static boolean videoCheck (InputStream inputStream) throws IOException {
-		List<String> validTypeList = Arrays.asList("video/mp4", "video/avi", "video/webm", "application/x-matroska", "video/quicktime");
+		List<String> validTypeList = Arrays.asList("video/mp4", "video/avi", "video/webm", "application/x-matroska", "video/quicktime", "application/octet-stream");
 		
 		String mimeType = tika.detect(inputStream);
 		log.info("MimeType : " + mimeType);

--- a/Backend/ifIDieTomorrow/src/test/java/com/a307/ifIDieTomorrow/domain/service/DiaryServiceImplTest.java
+++ b/Backend/ifIDieTomorrow/src/test/java/com/a307/ifIDieTomorrow/domain/service/DiaryServiceImplTest.java
@@ -252,8 +252,8 @@ class DiaryServiceImplTest {
 
 				// given
 				List<GetDiaryByUserResDto> expected = Arrays.asList(
-						new GetDiaryByUserResDto(1L, "Title 1", "Content 1", "imageUrl1", true, LocalDateTime.now(), LocalDateTime.now(), 1L),
-						new GetDiaryByUserResDto(2L, "Title 2", "Content 2", "imageUrl2", false, LocalDateTime.now(), LocalDateTime.now(), 2L)
+						new GetDiaryByUserResDto(1L, "Title 1", "Content 1", "imageUrl1", true, "image", LocalDateTime.now(), LocalDateTime.now(), 1L),
+						new GetDiaryByUserResDto(2L, "Title 2", "Content 2", "imageUrl2", false, "image", LocalDateTime.now(), LocalDateTime.now(), 2L)
 				);
 
 
@@ -291,7 +291,7 @@ class DiaryServiceImplTest {
 
 				// given
 				Long diaryId = 1L;
-				GetDiaryResDto diaryDto = new GetDiaryResDto(1L, 1L, "userNickname", "diaryTitle", "imageUrl", "diaryContent", true, LocalDateTime.now(), LocalDateTime.now());
+				GetDiaryResDto diaryDto = new GetDiaryResDto(1L, 1L, "userNickname", "diaryTitle", "imageUrl", "diaryContent", true, "image", LocalDateTime.now(), LocalDateTime.now());
 				List<GetCommentResDto> comments = List.of(
 						new GetCommentResDto(1L, "Test Comment 1", 2L, "user 2 nickname", LocalDateTime.now(), LocalDateTime.now()),
 						new GetCommentResDto(2L, "Test Comment 2", 3L, "user 3 nickname", LocalDateTime.now(), LocalDateTime.now())


### PR DESCRIPTION
Diary, Bucket, PhotoCloud의 영상 업로드가 허용됩니다. 
![image](https://github.com/brianpsw/If-I-die-tomorrow/assets/109469241/d181f2c2-2bcf-4b01-9849-a74f1e5a4278)
테이블의 컬럼 image_type으로 파일의 type을 구분합니다.
image_type == null -> 파일이 없음
image_type == image -> 이미지 파일
image_type == video -> 비디오 파일

개발용 DB의 기존 이미지들에 대하여 image_type을 image로 일괄 수정하였으나 배포용 서버의 DB도 수정해야 합니다.