### PR TITLE
[BE]feat: Create Notification Features

### DIFF
--- a/Backend/ifIDieTomorrow/build.gradle
+++ b/Backend/ifIDieTomorrow/build.gradle
@@ -66,6 +66,6 @@ dependencies {
 tasks.named('test') {
 	useJUnitPlatform()
 	filter{
-		excludeTestsMatching "*.NotificationTest"
+		excludeTestsMatching "*.NotificationUtilTest"
 	}
 }

--- a/Backend/ifIDieTomorrow/src/main/java/com/a307/ifIDieTomorrow/IfIDieTomorrowApplication.java
+++ b/Backend/ifIDieTomorrow/src/main/java/com/a307/ifIDieTomorrow/IfIDieTomorrowApplication.java
@@ -3,6 +3,7 @@ package com.a307.ifIDieTomorrow;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication(

--- a/Backend/ifIDieTomorrow/src/main/java/com/a307/ifIDieTomorrow/domain/controller/NotificationController.java
+++ b/Backend/ifIDieTomorrow/src/main/java/com/a307/ifIDieTomorrow/domain/controller/NotificationController.java
@@ -1,0 +1,40 @@
+package com.a307.ifIDieTomorrow.domain.controller;
+
+import com.a307.ifIDieTomorrow.domain.dto.comment.CreateCommentResDto;
+import com.a307.ifIDieTomorrow.domain.dto.community.GetPageDto;
+import com.a307.ifIDieTomorrow.domain.service.NotificationService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+@Tag(name = "알림", description = "APIs for NOTIFICATION")
+@RequestMapping("/notification")
+@Slf4j
+@RequiredArgsConstructor
+@RestController
+public class NotificationController {
+    private final NotificationService notificationService;
+    @GetMapping("")
+    @Operation(summary = "나에게 온 알림 리스트", description = "나에게 온 알림 리스트를 불러옵니다.")
+    public ResponseEntity<GetPageDto> getNotificationByUserId(
+            @RequestParam(name = "page", required = false) Integer pageNo,
+            @RequestParam(name = "size", required = false) Integer pageSize
+    ) {
+        return ResponseEntity.status(HttpStatus.OK).body(notificationService.getNotificationByUserId(pageNo, pageSize));
+    }
+
+    @GetMapping("/count")
+    @Operation(summary = "나에게 온 알림 개수", description = "내가 마지막으로 확인한 후 알림 개수를 불러옵니다.")
+    public ResponseEntity<Long> getNotificationCount() {
+        return ResponseEntity.status(HttpStatus.OK).body(notificationService.getNotificationCount());
+    }
+
+}

--- a/Backend/ifIDieTomorrow/src/main/java/com/a307/ifIDieTomorrow/domain/entity/Notification.java
+++ b/Backend/ifIDieTomorrow/src/main/java/com/a307/ifIDieTomorrow/domain/entity/Notification.java
@@ -1,0 +1,28 @@
+package com.a307.ifIDieTomorrow.domain.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.DynamicInsert;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@DynamicInsert
+@Table(name = "notification")
+public class Notification extends BaseEntity{
+
+	@Column
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long notificationId;
+
+	@Column(nullable = false)
+	private Long userId;
+
+}

--- a/Backend/ifIDieTomorrow/src/main/java/com/a307/ifIDieTomorrow/domain/repository/CommentRepository.java
+++ b/Backend/ifIDieTomorrow/src/main/java/com/a307/ifIDieTomorrow/domain/repository/CommentRepository.java
@@ -1,13 +1,19 @@
 package com.a307.ifIDieTomorrow.domain.repository;
 
+import com.a307.ifIDieTomorrow.domain.dto.comment.CreateCommentResDto;
 import com.a307.ifIDieTomorrow.domain.dto.comment.GetCommentResDto;
+import com.a307.ifIDieTomorrow.domain.dto.diary.GetDiaryResDto;
 import com.a307.ifIDieTomorrow.domain.entity.Comment;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import javax.transaction.Transactional;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
@@ -29,4 +35,35 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 			"FROM Comment " +
 			"WHERE userId = :userId")
 	void deleteAllByUserId (@Param("userId") Long userId);
+
+	@Query("SELECT NEW com.a307.ifIDieTomorrow.domain.dto.comment.CreateCommentResDto" +
+			"(c.commentId, c.content, u.nickname, c.type, c.typeId, c.createdAt, c.updatedAt) " +
+			"FROM Comment c " +
+			"JOIN User u " +
+			"ON c.userId = u.userId " +
+			"LEFT JOIN Diary d " +
+			"ON c.type = true and d.diaryId = c.typeId " +
+			"LEFT JOIN Bucket b " +
+			"ON c.type = false and b.bucketId = c.typeId " +
+			"where (d.userId = :userId OR b.userId = :userId) " +
+			"AND c.userId != :userId " +
+			"AND u.deleted = false " +
+			"ORDER BY d.createdAt DESC")
+	Page<CreateCommentResDto> findAllByUserId(Pageable pageable, @Param("userId") Long userId);
+
+	@Query("SELECT COUNT" +
+			"(c.commentId) " +
+			"FROM Comment c " +
+			"JOIN User u " +
+			"ON c.userId = u.userId " +
+			"LEFT JOIN Diary d " +
+			"ON c.type = true and d.diaryId = c.typeId " +
+			"LEFT JOIN Bucket b " +
+			"ON c.type = false and b.bucketId = c.typeId " +
+			"where (d.userId = :userId OR b.userId = :userId) " +
+			"AND c.userId != :userId " +
+			"AND u.deleted = false " +
+			"AND c.createdAt > :updatedTime " +
+			"ORDER BY d.createdAt DESC")
+	Long CountByUserIdAndUpdatedTime(@Param("userId") Long userId, @Param("updatedTime") LocalDateTime updatedAt);
 }

--- a/Backend/ifIDieTomorrow/src/main/java/com/a307/ifIDieTomorrow/domain/repository/NotificationRepository.java
+++ b/Backend/ifIDieTomorrow/src/main/java/com/a307/ifIDieTomorrow/domain/repository/NotificationRepository.java
@@ -1,0 +1,12 @@
+package com.a307.ifIDieTomorrow.domain.repository;
+
+import com.a307.ifIDieTomorrow.domain.entity.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+    Optional<Notification> findByUserId (Long userId);
+}

--- a/Backend/ifIDieTomorrow/src/main/java/com/a307/ifIDieTomorrow/domain/service/CommunityServiceImpl.java
+++ b/Backend/ifIDieTomorrow/src/main/java/com/a307/ifIDieTomorrow/domain/service/CommunityServiceImpl.java
@@ -103,7 +103,6 @@ public class CommunityServiceImpl implements CommunityService{
 
 
 		Comment comment = commentRepository.save(req.toEntity(userId));
-
 		return CreateCommentResDto.builder()
 				.commentId(comment.getCommentId())
 				.content(comment.getContent())
@@ -219,5 +218,4 @@ public class CommunityServiceImpl implements CommunityService{
 
 		return ReportResDto.toDto(report, reportCount);
 	}
-
 }

--- a/Backend/ifIDieTomorrow/src/main/java/com/a307/ifIDieTomorrow/domain/service/NotificationService.java
+++ b/Backend/ifIDieTomorrow/src/main/java/com/a307/ifIDieTomorrow/domain/service/NotificationService.java
@@ -1,0 +1,8 @@
+package com.a307.ifIDieTomorrow.domain.service;
+
+import com.a307.ifIDieTomorrow.domain.dto.community.GetPageDto;
+
+public interface NotificationService {
+    public GetPageDto getNotificationByUserId(Integer pageNo, Integer pageSize);
+    public Long getNotificationCount();
+}

--- a/Backend/ifIDieTomorrow/src/main/java/com/a307/ifIDieTomorrow/domain/service/NotificationServiceImpl.java
+++ b/Backend/ifIDieTomorrow/src/main/java/com/a307/ifIDieTomorrow/domain/service/NotificationServiceImpl.java
@@ -1,0 +1,85 @@
+package com.a307.ifIDieTomorrow.domain.service;
+
+import com.a307.ifIDieTomorrow.domain.dto.category.CreateCategoryResDto;
+import com.a307.ifIDieTomorrow.domain.dto.comment.CreateCommentResDto;
+import com.a307.ifIDieTomorrow.domain.dto.community.GetDiaryWithCommentDto;
+import com.a307.ifIDieTomorrow.domain.dto.community.GetPageDto;
+import com.a307.ifIDieTomorrow.domain.dto.diary.GetDiaryResDto;
+import com.a307.ifIDieTomorrow.domain.dto.photo.GetPhotoByCategoryResDto;
+import com.a307.ifIDieTomorrow.domain.entity.Notification;
+import com.a307.ifIDieTomorrow.domain.repository.CommentRepository;
+import com.a307.ifIDieTomorrow.domain.repository.NotificationRepository;
+import com.a307.ifIDieTomorrow.global.auth.UserPrincipal;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NotificationServiceImpl implements NotificationService{
+    private final CommentRepository commentRepository;
+    private final NotificationRepository notificationRepositoy;
+
+
+    @Override
+    public GetPageDto getNotificationByUserId(Integer pageNo, Integer pageSize) {
+        pageNo = Optional.ofNullable(pageNo).orElse(0);
+        pageSize = Optional.ofNullable(pageSize).orElse(10);
+        PageRequest pageable = PageRequest.of(pageNo, pageSize);
+
+        Optional<Notification> optionalNotification = getNotification();
+        if(optionalNotification.isPresent()){
+            Notification notification = optionalNotification.get();
+            notification.setUpdatedAt(LocalDateTime.now());
+            notificationRepositoy.save(notification);
+        } else {
+            notificationRepositoy.save(Notification.builder()
+                    .userId(((UserPrincipal) SecurityContextHolder.getContext().getAuthentication().getPrincipal()).getUserId()).build());
+            return new GetPageDto();
+        }
+
+//		페이징 객체
+        Page<CreateCommentResDto> result = commentRepository.findAllByUserId(pageable, ((UserPrincipal) SecurityContextHolder.getContext().getAuthentication().getPrincipal()).getUserId());
+
+//		dto 리스트로 변환
+        List<CreateCommentResDto> data = result.getContent();
+
+        return GetPageDto.builder()
+                .data(data)
+                .hasNext(result.hasNext())
+                .build();
+    }
+
+    @Override
+    public Long getNotificationCount() {
+
+        Optional<Notification> optionalNotification = getNotification();
+        LocalDateTime updatedTime;
+        if(optionalNotification.isPresent()){
+            Notification notification = optionalNotification.get();
+            updatedTime = notification.getUpdatedAt();
+        } else {
+            return 0L;
+        }
+
+        Long count = commentRepository.CountByUserIdAndUpdatedTime(((UserPrincipal) SecurityContextHolder.getContext().getAuthentication().getPrincipal()).getUserId(), updatedTime);
+        return count;
+    }
+
+    public Optional<Notification> getNotification(){
+        UserPrincipal principal = (UserPrincipal) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        Long userId = principal.getUserId();
+
+        return notificationRepositoy.findByUserId(userId);
+    }
+
+}

--- a/Backend/ifIDieTomorrow/src/main/java/com/a307/ifIDieTomorrow/global/config/JobConfiguration.java
+++ b/Backend/ifIDieTomorrow/src/main/java/com/a307/ifIDieTomorrow/global/config/JobConfiguration.java
@@ -4,7 +4,7 @@ import com.a307.ifIDieTomorrow.domain.dto.notification.SmsDto;
 import com.a307.ifIDieTomorrow.domain.dto.receiver.CreateReceiverResDto;
 import com.a307.ifIDieTomorrow.domain.entity.*;
 import com.a307.ifIDieTomorrow.domain.repository.*;
-import com.a307.ifIDieTomorrow.global.util.Notification;
+import com.a307.ifIDieTomorrow.global.util.NotificationUtil;
 import com.a307.ifIDieTomorrow.global.util.S3Upload;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -34,7 +34,7 @@ public class JobConfiguration {
 	private final JobBuilderFactory jobBuilderFactory;
 	private final StepBuilderFactory stepBuilderFactory;
 	private final UserRepository userRepository;
-	private final Notification notification;
+	private final NotificationUtil notificationUtil;
 	private final PhotoRepository photoRepository;
 	private final BucketRepository bucketRepository;
 	private final DiaryRepository diaryRepository;
@@ -170,7 +170,7 @@ public class JobConfiguration {
 		content.append("www.ifidietomorrow.co.kr/login").append(" 에 ").append("KAKAO".equals(user.getProviderType().toString()) ? "카카오" : "네이버").append(" 계정으로 로그인 해주세요.").append("\n");
 
 		try {
-			notification.sendSms(SmsDto.builder().smsContent(content.toString()).receiver(user.getPhone()).build());
+			notificationUtil.sendSms(SmsDto.builder().smsContent(content.toString()).receiver(user.getPhone()).build());
 		} catch (IOException e) {
 			log.error(e.getMessage());
 		}
@@ -201,7 +201,7 @@ public class JobConfiguration {
 			content.append("비밀번호 : ").append(uuid);
 			
 			try {
-				notification.sendSms(SmsDto.builder().smsContent(content.toString()).receiver(receiver.getPhoneNumber()).build());
+				notificationUtil.sendSms(SmsDto.builder().smsContent(content.toString()).receiver(receiver.getPhoneNumber()).build());
 			} catch (IOException e) {
 				log.error(e.getMessage());
 			}

--- a/Backend/ifIDieTomorrow/src/main/java/com/a307/ifIDieTomorrow/global/util/NotificationUtil.java
+++ b/Backend/ifIDieTomorrow/src/main/java/com/a307/ifIDieTomorrow/global/util/NotificationUtil.java
@@ -17,7 +17,7 @@ import java.util.Objects;
 
 @Slf4j
 @Component
-public class Notification {
+public class NotificationUtil {
     @Value("${notification.sms.id}")
     private String smsId;
     @Value("${notification.sms.url}")

--- a/Backend/ifIDieTomorrow/src/test/java/com/a307/ifIDieTomorrow/global/util/NotificationUtilTest.java
+++ b/Backend/ifIDieTomorrow/src/test/java/com/a307/ifIDieTomorrow/global/util/NotificationUtilTest.java
@@ -3,22 +3,18 @@ package com.a307.ifIDieTomorrow.global.util;
 import com.a307.ifIDieTomorrow.domain.dto.notification.SmsDto;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import java.io.IOException;
-import java.util.ArrayList;
 
-import static org.junit.jupiter.api.Assertions.*;
 @SpringBootTest
-class NotificationTest {
+class NotificationUtilTest {
 
     @Autowired
-    private Notification notification;
+    private NotificationUtil notificationUtil;
     @Test
     void sendSms() throws IOException {
         SmsDto smsDto = SmsDto.builder().smsContent("IfIDieTomorrow 테스트").receiver("전화번호").build();
-        notification.sendSms(smsDto);
+        notificationUtil.sendSms(smsDto);
     }
 }


### PR DESCRIPTION
Notification 부분을 새롭게 만들었습니다.

현재 있는 API는 두 개입니다.

첫째는 'api/notification/count" Get Method로 마지막 알림 리스트 확인 시간으로부터
지금까지 새롭게 쌓인 알림의 개수를 보여줍니다.

둘째는 "api/notification" Get Method로 알림 리스트를 보여줍니다.
지금 현재 알림을 보내는 형태가 댓글을 달았을 때의 경우만 있다보니 내가 쓴 글에 다른 사람이 적은 댓글 리스트를 불러옵니다.
현재는 작성 시간과 상관 없이 모든 댓글이 오도록 만들어져 있습니다. 따라서 댓글 양이 많을 것을 생각해서 pagination을 적용했고,
이는 무한 스크롤 혹은 page 넘기는 것에 활용 가능할 것으로 보입니다.
또한 알림 리스트 확인 시간을 업데이트합니다. (첫번째 method 리턴 값에 영향을 줌)

