### PR TITLE
Be/feat/photo service impl test

### DIFF
--- a/Backend/ifIDieTomorrow/src/main/java/com/a307/ifIDieTomorrow/domain/controller/PhotoController.java
+++ b/Backend/ifIDieTomorrow/src/main/java/com/a307/ifIDieTomorrow/domain/controller/PhotoController.java
@@ -57,7 +57,7 @@ public class PhotoController {
 	@PatchMapping("/category")
 	@Operation(summary = "카테고리 이름 변경", description = "카테고리 이름을 변경합니다.")
 	public ResponseEntity<CreateCategoryResDto> updateCategoryName(
-			@RequestBody UpdateCategoryNameDto data) throws NotFoundException, IllegalArgumentException {
+			@RequestBody UpdateCategoryNameDto data) throws NotFoundException, IllegalArgumentException, UnAuthorizedException {
 		return ResponseEntity.status(HttpStatus.OK).body(photoService.updateCategoryName(data));
 	}
 	
@@ -66,7 +66,7 @@ public class PhotoController {
 	public ResponseEntity<CreateCategoryResDto> updateCategoryThumbnail(
 			@RequestPart UpdateCategoryThumbnailDto data,
 			@RequestPart MultipartFile image
-			) throws ImageProcessingException, NotFoundException, IOException, IllegalArgumentException, NoPhotoException, MetadataException {
+			) throws ImageProcessingException, NotFoundException, IOException, NoPhotoException, MetadataException, UnAuthorizedException {
 		return ResponseEntity.status(HttpStatus.OK).body(photoService.updateCategoryThumbnail(data, image));
 	}
 	

--- a/Backend/ifIDieTomorrow/src/main/java/com/a307/ifIDieTomorrow/domain/service/PhotoService.java
+++ b/Backend/ifIDieTomorrow/src/main/java/com/a307/ifIDieTomorrow/domain/service/PhotoService.java
@@ -22,7 +22,7 @@ import java.util.List;
 public interface PhotoService {
 	CreateCategoryResDto createCategory (CreateCategoryDto data, MultipartFile image) throws UnAuthorizedException, IllegalArgumentException, ImageProcessingException, IOException, MetadataException, NoPhotoException;
 	
-	CreateCategoryResDto updateCategoryName (UpdateCategoryNameDto data) throws NotFoundException, IllegalArgumentException;
+	CreateCategoryResDto updateCategoryName (UpdateCategoryNameDto data) throws NotFoundException, IllegalArgumentException, UnAuthorizedException;
 	
 	Long deleteCategory (Long categoryId) throws NotFoundException, IllegalArgumentException;
 	
@@ -40,5 +40,5 @@ public interface PhotoService {
 
 	List<GetPhotoByCategoryResDto> getPhotoByUser (Long userId);
 	
-	CreateCategoryResDto updateCategoryThumbnail (UpdateCategoryThumbnailDto data, MultipartFile image) throws NotFoundException, IllegalArgumentException, NoPhotoException, ImageProcessingException, IOException, MetadataException;
+	CreateCategoryResDto updateCategoryThumbnail (UpdateCategoryThumbnailDto data, MultipartFile image) throws NotFoundException, NoPhotoException, ImageProcessingException, IOException, MetadataException, UnAuthorizedException;
 }

--- a/Backend/ifIDieTomorrow/src/main/java/com/a307/ifIDieTomorrow/domain/service/PhotoServiceImpl.java
+++ b/Backend/ifIDieTomorrow/src/main/java/com/a307/ifIDieTomorrow/domain/service/PhotoServiceImpl.java
@@ -74,12 +74,12 @@ public class PhotoServiceImpl implements PhotoService {
 	}
 	
 	@Override
-	public CreateCategoryResDto updateCategoryName (UpdateCategoryNameDto data) throws NotFoundException, IllegalArgumentException {
+	public CreateCategoryResDto updateCategoryName (UpdateCategoryNameDto data) throws NotFoundException, IllegalArgumentException, UnAuthorizedException {
 		Category category = categoryRepository.findByCategoryId(data.getCategoryId())
 				.orElseThrow(() -> new NotFoundException("존재하지 않는 카테고리 ID 입니다."));
 		
 		if (category.getUserId() != ((UserPrincipal) SecurityContextHolder.getContext().getAuthentication().getPrincipal()).getUserId())
-			throw new IllegalArgumentException("카테고리 수정 권한이 없습니다.");
+			throw new UnAuthorizedException("카테고리 수정 권한이 없습니다.");
 		
 		if (data.getName() == null || "".equals(data.getName().trim()))
 			throw new IllegalArgumentException("카테고리 이름이 없습니다.");
@@ -90,12 +90,12 @@ public class PhotoServiceImpl implements PhotoService {
 	}
 	
 	@Override
-	public CreateCategoryResDto updateCategoryThumbnail (UpdateCategoryThumbnailDto data, MultipartFile image) throws NotFoundException, IllegalArgumentException, NoPhotoException, ImageProcessingException, IOException, MetadataException {
+	public CreateCategoryResDto updateCategoryThumbnail (UpdateCategoryThumbnailDto data, MultipartFile image) throws NotFoundException, NoPhotoException, ImageProcessingException, IOException, MetadataException, UnAuthorizedException {
 		Category category = categoryRepository.findByCategoryId(data.getCategoryId())
 				.orElseThrow(() -> new NotFoundException("존재하지 않는 카테고리 ID 입니다."));
 		
 		if (category.getUserId() != ((UserPrincipal) SecurityContextHolder.getContext().getAuthentication().getPrincipal()).getUserId())
-			throw new IllegalArgumentException("카테고리 수정 권한이 없습니다.");
+			throw new UnAuthorizedException("카테고리 수정 권한이 없습니다.");
 		
 		if (image == null || image.isEmpty()) throw new NoPhotoException("사진이 없습니다.");
 		


### PR DESCRIPTION
1. 아래의 테스트 코드가 추가되었습니다.

카테고리 생성
  - 실패 케이스
    - 썸네일이 없는 카테고리 생성
    - 이름이 없는 카테고리 생성
 
카테고리 조회
  - 성공 케이스
    - 내 카테고리 조회

카테고리 수정(이름)
  - 성공 케이스
    - 이름이 입력된 카테고리 수정
  - 실패 케이스
    - 존재하지 않는 카테고리 수정
    - 다른 유저의 카테고리 수정
    - 이름이 입력되지 않은 카테고리 수정

카테고리 수정(사진)
  - 성공 케이스
    - 사진이 입력된 카테고리 수정
  - 실패 케이스
    - 존재하지 않는 카테고리 수정
    - 다른 유저의 카테고리 수정
    - 사진이 입력되지 않은 카테고리 수정

2. 다른 유저의 카테고리에 접근할 때 UnAuthorized 예외가 발생하도록 수정했습니다.