### PR TITLE
Be/feat/photo service impl test

### DIFF
--- a/Backend/ifIDieTomorrow/src/main/java/com/a307/ifIDieTomorrow/domain/controller/PhotoController.java
+++ b/Backend/ifIDieTomorrow/src/main/java/com/a307/ifIDieTomorrow/domain/controller/PhotoController.java
@@ -73,7 +73,7 @@ public class PhotoController {
 	@DeleteMapping("/category/{categoryId}")
 	@Operation(summary = "카테고리 삭제", description = "카테고리를 삭제합니다.")
 	public ResponseEntity<Long> deleteCategory(
-			@PathVariable Long categoryId) throws NotFoundException, IllegalArgumentException {
+			@PathVariable Long categoryId) throws NotFoundException, UnAuthorizedException {
 		return ResponseEntity.status(HttpStatus.NO_CONTENT).body(photoService.deleteCategory(categoryId));
 	}
 	

--- a/Backend/ifIDieTomorrow/src/main/java/com/a307/ifIDieTomorrow/domain/service/PhotoService.java
+++ b/Backend/ifIDieTomorrow/src/main/java/com/a307/ifIDieTomorrow/domain/service/PhotoService.java
@@ -24,7 +24,7 @@ public interface PhotoService {
 	
 	CreateCategoryResDto updateCategoryName (UpdateCategoryNameDto data) throws NotFoundException, IllegalArgumentException, UnAuthorizedException;
 	
-	Long deleteCategory (Long categoryId) throws NotFoundException, IllegalArgumentException;
+	Long deleteCategory (Long categoryId) throws NotFoundException, UnAuthorizedException;
 	
 	List<CreateCategoryResDto> getCategory ();
 	

--- a/Backend/ifIDieTomorrow/src/main/java/com/a307/ifIDieTomorrow/domain/service/PhotoServiceImpl.java
+++ b/Backend/ifIDieTomorrow/src/main/java/com/a307/ifIDieTomorrow/domain/service/PhotoServiceImpl.java
@@ -106,12 +106,12 @@ public class PhotoServiceImpl implements PhotoService {
 	}
 	
 	@Override
-	public Long deleteCategory (Long categoryId) throws NotFoundException, IllegalArgumentException {
+	public Long deleteCategory (Long categoryId) throws NotFoundException, UnAuthorizedException {
 		Category category = categoryRepository.findByCategoryId(categoryId)
 				.orElseThrow(() -> new NotFoundException("존재하지 않는 카테고리 ID 입니다."));
 		
 		if (category.getUserId() != ((UserPrincipal) SecurityContextHolder.getContext().getAuthentication().getPrincipal()).getUserId())
-			throw new IllegalArgumentException("카테고리 수정 권한이 없습니다.");
+			throw new UnAuthorizedException("카테고리 수정 권한이 없습니다.");
 		
 		// 카테고리에 엮인 사진 모두 삭제
 		photoRepository.deleteAllByCategory_CategoryId(categoryId);


### PR DESCRIPTION
1. 아래의 테스트 코드가 추가되었습니다.
### 카테고리
카테고리 삭제
  - 성공 케이스
    - 내 카테고리 삭제
  - 실패 케이스
    - 존재하지 않는 카테고리 삭제
    - 다른 유저의 카테고리 삭제

### 포토클라우드
포토 생성
  - 성공 케이스
    - 사진과 캡션이 있는 포토 생성
  - 실패 케이스
    - 사진이 없는 포토 생성
    - 존재하지 않는 카테고리에 포토 생성
    - 다른 유저의 카테고리에 포토 생성

2. 다른 유저의 카테고리에 접근할 때 UnAuthorized 예외가 발생하도록 수정했습니다.