### PR TITLE
👻[BE]feat: PhotoServiceImplTest 구현

### DIFF
--- a/Backend/ifIDieTomorrow/src/main/java/com/a307/ifIDieTomorrow/domain/entity/Photo.java
+++ b/Backend/ifIDieTomorrow/src/main/java/com/a307/ifIDieTomorrow/domain/entity/Photo.java
@@ -35,7 +35,7 @@ public class Photo extends BaseEntity {
 	
 	private String imageType;
 	
-	public void updateCategory (String caption) {
+	public void updateCaption(String caption) {
 		this.caption = caption;
 	}
 	

--- a/Backend/ifIDieTomorrow/src/main/java/com/a307/ifIDieTomorrow/domain/service/PhotoServiceImpl.java
+++ b/Backend/ifIDieTomorrow/src/main/java/com/a307/ifIDieTomorrow/domain/service/PhotoServiceImpl.java
@@ -165,7 +165,7 @@ public class PhotoServiceImpl implements PhotoService {
 		// 본인의 사진이 아닌 경우
 		if (!photo.getUserId().equals(userId)) throw new UnAuthorizedException("접근할 수 없는 포토 ID 입니다.");
 		
-		photo.updateCategory(data.getCaption());
+		photo.updateCaption(data.getCaption());
 		
 		return CreatePhotoResDto.toDto(photoRepository.save(photo));
 	}

--- a/Backend/ifIDieTomorrow/src/test/java/com/a307/ifIDieTomorrow/domain/service/PhotoServiceImplTest.java
+++ b/Backend/ifIDieTomorrow/src/test/java/com/a307/ifIDieTomorrow/domain/service/PhotoServiceImplTest.java
@@ -699,7 +699,7 @@ public class PhotoServiceImplTest {
 				
 				@Test
 				@DisplayName("캡션이 입력된 포토 수정")
-				void updateCategory() throws NotFoundException, UnAuthorizedException {
+				void updateCaption() throws NotFoundException, UnAuthorizedException {
 					
 					// Given
 					Photo savedPhoto = Photo.builder()


### PR DESCRIPTION
1. 아래의 테스트 코드가 추가되었습니다.

### 포토클라우드

포토 수정
- 성공 케이스
  - 캡션이 입력된 포토 수정
- 실패 케이스
  - 존재하지 않는 포토 수정
  - 다른 유저의 포토 수정

포토 삭제
- 성공 케이스
  - 내 포토 삭제
- 실패 케이스
  - 존재하지 않는 포토 수정
  - 다른 유저의 포토 수정

2. Photo Entity의 updateCategory가 updateCaption으로 수정되었습니다.
오타 수정